### PR TITLE
Update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708591310,
-        "narHash": "sha256-8mQGVs8JccWTnORgoLOTh9zvf6Np+x2JzhIc+LDcJ9s=",
+        "lastModified": 1710164657,
+        "narHash": "sha256-l64+ZjaQAVkHDVaK0VHwtXBdjcBD6nLBD+p7IfyBp/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e0e9669547e45ea6cca2de4044c1a384fd0fe55",
+        "rev": "017b12de5b899ef9b64e2c035ce257bfe95b8ae2",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708225687,
-        "narHash": "sha256-NJBDfvknI26beOFmjO2coeJMTTUCCtw2Iu+rvJ1Zb9k=",
+        "lastModified": 1710120787,
+        "narHash": "sha256-tlLuB73OCOKtU2j83bQzSYFyzjJo3rjpITZE5MoofG8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "17352eb241a8d158c4ac523b19d8d2a6c8efe127",
+        "rev": "e76ff2df6bfd2abe06abd8e7b9f217df941c1b07",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708710706,
-        "narHash": "sha256-wv5Lx30FIqnaLXWGnVlSve1BB1JJNqsy6Ss9aBRvqrw=",
+        "lastModified": 1710256118,
+        "narHash": "sha256-r+kKiMYHdi+ww/Q7eJKMKnwBhWtC3dUrDQFkgusAVZU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f81b2dee02b8337dc58fd0edb93eefd67e518b0",
+        "rev": "93ecdaa1f34354c9476062dc4fe323b442c087d5",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701957584,
-        "narHash": "sha256-xEpFaRdrneHl3Xdyzp3emd4QVxML7AR3GC91wuWi0Ok=",
+        "lastModified": 1709054971,
+        "narHash": "sha256-3IwfLOCKF/aGzjG79GCsj/ZxZF0hQYbitFyzekSYDwk=",
         "owner": "numtide",
         "repo": "nixpkgs-unfree",
-        "rev": "127b9b18583de04c6207c2a0e674abf64fc4a3b1",
+        "rev": "1cfef288e8ddfb79fba9e11cc869ccf1bcfc01e6",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708564076,
-        "narHash": "sha256-KKkqoxlgx9n3nwST7O2kM8tliDOijiSSNaWuSkiozdQ=",
+        "lastModified": 1710222005,
+        "narHash": "sha256-irXySffHz7b82dZIme6peyAu+8tTJr1zyxcfUPhqUrg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
+        "rev": "9a9a7552431c4f1a3b2eee9398641babf7c30d0e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
                   ./home/window-managers/kde
                   ./home/cli/core
                   ./home/cli/mpd
-                  ./home/cli/cuda
+                  # ./home/cli/cuda
                   ./home/cli/programming/all.nix
                   ./home/gui/core
                   ./home/gui/vscode

--- a/home/cli/programming/rust.nix
+++ b/home/cli/programming/rust.nix
@@ -2,8 +2,8 @@
   nixpkgs.overlays = [
     (import "${
         fetchTarball {
-            url = "https://github.com/nix-community/fenix/archive/4b07da0f91ea99f263f47165a11a48678c9e0dc3.tar.gz";
-            sha256 = "sha256:13rmlpf7igvilg1xx1jrrcvjvviabbgjlby4g9dvvxx8fr3xwz9i";
+            url = "https://github.com/nix-community/fenix/archive/12222a90a7e02443f822e679055858d786e7324f.tar.gz";
+            sha256 = "sha256:1l818fc5x296hlma8zb5g1n2xwx0k6fxnk7x8dzbgk6px0d9bx9h";
         }
     }/overlay.nix")
   ];


### PR DESCRIPTION
Note due to [CVE-2024-27297](https://cve.mitre.org/cgi-bin/cvename.cgi\?name\=2024-27297), you have to `export NIXPKGS_ALLOW_INSECURE=1` and add the `--impure` flag